### PR TITLE
Workaround bug for continuation lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,14 +8,10 @@ Maintainer: Steve Lianoglou <slianoglou@gmail.com>
 Description: This package provides an interface to "shotgun", the
   (large-scale) parallel coordinate decent solver for lasso and sparse
   logistic regression written in C++. Sparse design matrices are supported
-  via the Matrix package.
-  .
-  The shotgun C++ library is developed in the SELECT Lab at CMU by
+  via the Matrix package.  The shotgun C++ library is developed in the SELECT Lab at CMU by
   Aapo Kyrola, Joseph Bradley, Danny Bickson, and Carlos Guestrin. See
   their ICML 2011 paper and its home page for more information (links listed
-  in URLs below)
-  .
-  NOTE: This package only runs on x86_64 bit architectures and probably does
+  in URLs below).  NOTE: This package only runs on x86_64 bit architectures and probably does
   not work on Windows.
 License: Apache-2
 LazyLoad: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,12 +9,12 @@ Description: This package provides an interface to "shotgun", the
   (large-scale) parallel coordinate decent solver for lasso and sparse
   logistic regression written in C++. Sparse design matrices are supported
   via the Matrix package.
-  .
+  
   The shotgun C++ library is developed in the SELECT Lab at CMU by
   Aapo Kyrola, Joseph Bradley, Danny Bickson, and Carlos Guestrin. See
   their ICML 2011 paper and its home page for more information (links listed
   in URLs below)
-  .
+  
   NOTE: This package only runs on x86_64 bit architectures and probably does
   not work on Windows.
 License: Apache-2

--- a/README
+++ b/README
@@ -1,3 +1,6 @@
+# drkneuxs Note
+This was just a tiny bug fix stub over here.  The code does not appear to run in parallel as implemented.
+
 ==============================================================================
 >>>>>             This project is currently under construction           <<<<<
 >>>>>             It works but is still rough around the edges           <<<<<


### PR DESCRIPTION
Formatting DESCRIPTION in this way allows for buckshot to be installed from devtools via install_github.  The issue is devtools' handling of the DESCRIPTION file, so this is just a work around for usablity.  c.f. https://github.com/eddelbuettel/drat/issues/1 and https://github.com/hadley/devtools/issues/709.
